### PR TITLE
SP-72 Trigger end_session_endpoint from Ansattporten

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
+<<<<<<< Updated upstream
 # Maskinporten Onboarding: Backend
 
 ## Development
 
 Run application with [Spring Profile](https://www.baeldung.com/spring-profiles) `dev` to use the default development environment.
+=======
+# Makinporten-onboaring-backend
+
+## Development
+
+Requires env-variables 
+```
+ANSATTPORTEN_CLIENT_ID
+ANSATTPORTEN_CLIENT_SECRET
+SIMPLIFIED_ONBOARDING_FRONTEND_URL
+ANSATTPORTEN_LOGIN_BASE_URL
+ANSATTPORTEN_API_BASE_URL
+```
+>>>>>>> Stashed changes
 
 Additionally, you must inject the _ansattporten client secret_ in the context.
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,6 @@
-<<<<<<< Updated upstream
-# Maskinporten Onboarding: Backend
-
-## Development
-
-Run application with [Spring Profile](https://www.baeldung.com/spring-profiles) `dev` to use the default development environment.
-=======
 # Makinporten-onboaring-backend
 
 ## Development
-
-Requires env-variables 
-```
-ANSATTPORTEN_CLIENT_ID
-ANSATTPORTEN_CLIENT_SECRET
-SIMPLIFIED_ONBOARDING_FRONTEND_URL
-ANSATTPORTEN_LOGIN_BASE_URL
-ANSATTPORTEN_API_BASE_URL
-```
->>>>>>> Stashed changes
 
 Additionally, you must inject the _ansattporten client secret_ in the context.
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,16 +17,10 @@
 		<java.version>17</java.version>
 		<snakeyaml.version>2.0</snakeyaml.version><!-- To avoid CVE-2022-1471  -->
 		<spring-cloud.version>2022.0.4</spring-cloud.version>
-		<idporten-actuator.version>1.0.1</idporten-actuator.version>
+		<idporten-actuator.version>1.1.0</idporten-actuator.version>
+		<logback.version>1.4.12</logback.version>
 	</properties>
 	<dependencies>
-
-		<!-- fix logging vulnerability -->
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.4.14</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.2.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>no.digdir</groupId>
@@ -20,6 +20,14 @@
 		<idporten-actuator.version>1.0.1</idporten-actuator.version>
 	</properties>
 	<dependencies>
+
+		<!-- fix logging vulnerability -->
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.4.14</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>

--- a/src/main/java/no/digdir/simplifiedonboarding/AppController.java
+++ b/src/main/java/no/digdir/simplifiedonboarding/AppController.java
@@ -3,12 +3,12 @@ package no.digdir.simplifiedonboarding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,13 +39,13 @@ public class AppController {
     @GetMapping("/config")
     public Map<String, Map<String, String>> getConfiguration() throws Throwable {
         logger.info("Fetching config");
-        HashMap<String, Map<String, String>> map = new HashMap<>();
+        HashMap<String, Map<String, String>> map = new LinkedHashMap<>();
 
         //This should be rewritten to fetch issuer and token_endpoint from config.getAuthorizationServer() + "/.well-known/oauth-authorization-server". in accordance with https://datatracker.ietf.org/doc/html/rfc8414#section-3
 
         for ( String e : maskinportenConfig.getEnvironments()) {
             MaskinportenConfig.EnvironmentConfig config = maskinportenConfig.getConfigFor(e);
-            HashMap<String, String> envSpesifics = new HashMap<>();
+            HashMap<String, String> envSpesifics = new LinkedHashMap<>();
             envSpesifics.put("issuer", config.getAuthorizationServer()+ "/");
             envSpesifics.put("token_endpoint", config.getAuthorizationServer()+ "/token");
             envSpesifics.put("authorization_server", config.getAuthorizationServer());

--- a/src/main/java/no/digdir/simplifiedonboarding/MaskinportenConfig.java
+++ b/src/main/java/no/digdir/simplifiedonboarding/MaskinportenConfig.java
@@ -21,11 +21,17 @@ public class MaskinportenConfig {
     }
 
     public List<String> getEnvironments(){
-        return getMaskinportenConfig().stream().map(environmentConfig -> environmentConfig.getEnvironment()).collect(Collectors.toList());
+        return getMaskinportenConfig()
+                .stream()
+                .map(EnvironmentConfig::getEnvironment)
+                .collect(Collectors.toList());
     }
 
     public EnvironmentConfig getConfigFor(String environment) throws Throwable {
-        Optional<EnvironmentConfig> environmentConfigOptional = getMaskinportenConfig().stream().filter(environmentConfig -> environmentConfig.getEnvironment().equalsIgnoreCase(environment)).findFirst();
+        Optional<EnvironmentConfig> environmentConfigOptional = getMaskinportenConfig()
+                .stream()
+                .filter(environmentConfig -> environmentConfig.getEnvironment().equalsIgnoreCase(environment))
+                .findFirst();
         return environmentConfigOptional.orElseThrow((Supplier<Throwable>) UnsupportedOperationException::new);
     }
 

--- a/src/main/java/no/digdir/simplifiedonboarding/security/SecurityConfig.java
+++ b/src/main/java/no/digdir/simplifiedonboarding/security/SecurityConfig.java
@@ -1,18 +1,17 @@
 package no.digdir.simplifiedonboarding.security;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.server.CookieSameSiteSupplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
-import org.springframework.security.web.server.authentication.RedirectServerAuthenticationEntryPoint;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -29,6 +28,9 @@ public class SecurityConfig {
     @Value("${frontend.uri}")
     private String frontendApplication;
 
+    @Autowired
+    ClientRegistrationRepository clientRegistrationRepository;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -40,7 +42,8 @@ public class SecurityConfig {
                         .requestMatchers("/health/**", "/info/**", "/version/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .logout((logout) -> logout.logoutSuccessUrl(frontendApplication))
+                .logout((logout) -> logout
+                        .logoutSuccessHandler(oidcLogoutSuccessHandler()))
                 .oauth2Login(oauth2 -> oauth2
                         .defaultSuccessUrl(frontendApplication + "/dashboard", true)
                         .failureHandler(authenticationFailureHandler())
@@ -64,6 +67,15 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/api/**", configuration);
         return source;
+    }
+
+    public OidcClientInitiatedLogoutSuccessHandler oidcLogoutSuccessHandler() {
+        OidcClientInitiatedLogoutSuccessHandler successHandler = new OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository);
+
+        // As registered in samarbeidsportalen
+        String postLogoutRedirectUri = frontendApplication;
+        successHandler.setPostLogoutRedirectUri(postLogoutRedirectUri);
+        return successHandler;
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,5 +68,5 @@ server:
     session:
       cookie:
         secure: true
-        max-age: 10m
+        max-age: 120m
       timeout: 10m


### PR DESCRIPTION
spring-security triggers end_session_endpoint from discovery document at https://test.ansattporten.no/.well-known/openid-configuration (derived from issuer-uri in application.yaml) when OIDC logout handler is defined and post logout uri is updated in ansattporten-client-configuration.

--

Basert på Jørgen sin input om at Ansattporten tilbyr en isolert [SSO-sesjon](https://docs.digdir.no/docs/idporten/oidc/oidc_func_nosso.html), så forstår jeg det på denne måten: Vi trenger å håndtere 
* lokal logout (det var det vi allerede gjortd) https://docs.spring.io/spring-security/reference/reactive/oauth2/login/logout.html
* [logout mot Ansattporten som IDP](https://docs.digdir.no/docs/idporten/oidc/oidc_func_sso#1-utlogging-fra-egen-tjeneste-logout) (url defineres pr spec i end_session_endpoint på [well-known-endepunkt](https://test.ansattporten.no/.well-known/openid-configuration)). Dekkes av denne PRen.

Vi trenger ikke å håndtere [logout fra andre tjenester](https://docs.digdir.no/docs/idporten/oidc/oidc_func_sso#2-håndtere-utlogging-fra-id-porten-front-channel-logout)  siden Ansattporten har en isolert SSO-sesjon.

--

Thor Kristian oppdaterte “Gyldig(e) post logout redirect uri-er*” er på ansattporten-integrasjonen med client_id forenklet_onboarding_dev for meg, men dette må vi gjøre tilsvarende i andre miljøer. Jeg har satt at env-variablen`SIMPLIFIED_ONBOARDING_FRONTEND_URL` er “Gyldig(e) post logout redirect uri-er*” sånn som det er nå