### PR TITLE
SP-00: Upgrade Spring Boot to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.2.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>no.digdir</groupId>

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,8 @@
 # Bare minimum overrides to avoid auto-config fails while running tests
 
+management:
+  server:
+    port:  # Sets management port to same as server.port (default=8080)
 maskinporten-config:
   - environment: aaa
     api: bbb


### PR DESCRIPTION
We had originally reverted to 3.1.5, but this has now been flagged with a high vulnerability -> CVE-2023-34053.

Easiest fix seems to be a 3.2.0 upgrade.