### PR TITLE
SP-165 Add logback-spring.xml as in docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<spring-cloud.version>2022.0.4</spring-cloud.version>
 		<idporten-actuator.version>1.1.0</idporten-actuator.version>
 		<logback.version>1.4.12</logback.version>
+		<logstash.logback.version>7.4</logstash.logback.version>
 	</properties>
 	<dependencies>
 
@@ -52,6 +53,12 @@
 			<groupId>no.idporten.actuator</groupId>
 			<artifactId>idporten-actuator-starter</artifactId>
 			<version>${idporten-actuator.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>net.logstash.logback</groupId>
+			<artifactId>logstash-logback-encoder</artifactId>
+			<version>${logstash.logback.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <springProperty name="APP-NAME" source="spring.application.name" defaultValue="-"/>
+    <springProperty name="APP-ENV" source="spring.application.environment" defaultValue="-"/>
+    <springProfile name="dev">
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <appender name="APPLICATION" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdc>true</includeMdc>
+            <customFields>{"application":"${APP-NAME}","environment":"${APP-ENV}","logtype":"application"}</customFields>
+        </encoder>
+    </appender>
+    <springProfile name="!dev">
+        <logger name="no.digdir" level="INFO">
+            <appender-ref ref="APPLICATION"/>
+        </logger>
+
+    </springProfile>
+</configuration>


### PR DESCRIPTION
Startet på https://paotvers.io/docs/guides/logging/ pluss mer fra [idporten-saml2-client-service](https://github.com/felleslosninger/idporten-saml2-client-service/tree/main)

Loggformatet ser ut til å bli JSON på formatet som er ønsket, meg jeg klarer ikke å connect-the-dots på hvordan loade denne som rett logback-config. Testet den ved å rename til logback.xml, men da plukker den ikke opp spring-profile